### PR TITLE
fix(config): thrown an error if an option is wrongly set

### DIFF
--- a/src/rules/sort-attribute-content/sort-attribute-content.rule.ts
+++ b/src/rules/sort-attribute-content/sort-attribute-content.rule.ts
@@ -42,6 +42,16 @@ export const sortAttributeContentRule: Rule.RuleModule = {
 			(context.options as [SortAttributeContentOptions])[0]
 		);
 
+		if (ruleOptions.length === 0) {
+			throw new Error("There is no options defined for this rule.");
+		}
+		if (ruleOptions.some(({ attributes }) => attributes.length === 0)) {
+			throw new Error("At least one of the options have no attributes");
+		}
+		if (ruleOptions.some(({ separator }) => separator.length === 0)) {
+			throw new Error("At least one of the options have an empty separator");
+		}
+
 		/**
 		 * @param content The attribute value
 		 * @param options The sort options
@@ -54,9 +64,6 @@ export const sortAttributeContentRule: Rule.RuleModule = {
 			nodeInfo: Pick<AttributeNode, "loc" | "range"> & { attribute: string }
 		) {
 			const { caseSensitive, direction, separator } = options;
-			if (!separator.length) {
-				throw new Error("Can not sort attribute content with an empty separator.");
-			}
 
 			const parts = splitString(
 				content,

--- a/test/e2e/e2e.spec.ts
+++ b/test/e2e/e2e.spec.ts
@@ -1,0 +1,36 @@
+import { parseForESLint } from "@html-eslint/parser";
+import { Linter } from "eslint";
+
+import {
+	SORT_ATTRIBUTE_CONTENT_NAME,
+	SortAttributeContentOptions,
+	sortAttributeContentRule
+} from "../../src/rules";
+
+describe("e2e", () => {
+	const parser = "@html-eslint/parser";
+	const linter = new Linter();
+
+	linter.defineParser(parser, { parseForESLint: parseForESLint as never });
+	linter.defineRule(SORT_ATTRIBUTE_CONTENT_NAME, sortAttributeContentRule);
+
+	const verify = (options: SortAttributeContentOptions) =>
+		linter.verify("<div></div>", {
+			parser,
+			rules: {
+				[SORT_ATTRIBUTE_CONTENT_NAME]: ["error", options]
+			}
+		});
+
+	it("should throw an error when no option is set", () => {
+		expect(() => verify([])).toThrow("no options");
+	});
+
+	it("should throw an error when `attributes` is empty", () => {
+		expect(() => verify([{ attributes: [] }])).toThrow("no attributes");
+	});
+
+	it("should throw an error when the `separator` is an empty string", () => {
+		expect(() => verify([{ attributes: "class", separator: "" }])).toThrow("empty separator");
+	});
+});


### PR DESCRIPTION
Errors such as: No options defined for the rule, no attributes or empty separator `""` fixes #6